### PR TITLE
Update False Positive (FP) calculation

### DIFF
--- a/PatRec/Accuracy_patRec.m
+++ b/PatRec/Accuracy_patRec.m
@@ -1,14 +1,14 @@
 % ---------------------------- Copyright Notice ---------------------------
-% This file is part of BioPatRec © which is open and free software under 
+% This file is part of BioPatRec Â© which is open and free software under 
 % the GNU Lesser General Public License (LGPL). See the file "LICENSE" for 
 % the full license governing this code and copyrights.
 %
 % BioPatRec was initially developed by Max J. Ortiz C. at Integrum AB and 
-% Chalmers University of Technology. All authors’ contributions must be kept
+% Chalmers University of Technology. All authorsâ€™ contributions must be kept
 % acknowledged below in the section "Updates % Contributors". 
 %
 % Would you like to contribute to science and sum efforts to improve 
-% amputees’ quality of life? Join this project! or, send your comments to:
+% amputeesâ€™ quality of life? Join this project! or, send your comments to:
 % maxo@chalmers.se.
 %
 % The entire copyright notice must be kept in this or any source file 
@@ -157,7 +157,7 @@ end
 acc(i+1) = sum(good) / size(tSet,1);
 tPvec = sum(tPvec)';
 tNvec = sum(tNvec)';
-fPvec = sum(fPvec)';
+fPvec = sum(fPvec')';   % transpose to sum the false positives in each predicted class (corresponds to each row, whereas ground truth is given by column)
 fNvec = sum(fNvec)';
 
 %Compute the precision per movement


### PR DESCRIPTION
It seems like there is a "bug" when summing up the False Positive results (fPvec in Accuracy_patRec.m).
In consequence, the Precision and F1 scores are not always correct.

**Reason:** 
FP are summed up over the true values -> leading to the same number of FP as FN for each class
FP should be summed up over the predicted class -> that way the wrong predictions are referenced to the right class

**Solution:**
Transpose the matrix (fPvec) before summing up the FP values for each predicted class